### PR TITLE
[ethwol] disable vfd if WakeOnLAN is enabled

### DIFF
--- a/recipes-bsp/drivers/abcom-ethwol.bb
+++ b/recipes-bsp/drivers/abcom-ethwol.bb
@@ -19,6 +19,7 @@ if [ $? -eq 0 ]
 then
 	echo [WOL] activate WakeOnLAN at device eth0
 	ethtool -s eth0 wol g
+	echo '0' > /proc/stb/power/vfd
 else
 	echo [WOL] WakeOnLAN is not enabled
 fi


### PR DESCRIPTION
If  turn on the "Wake on Lan"(set  'on' /proc/stb/power/wol) and put the receiver into deep standby mode, the display does not turn off.